### PR TITLE
Safari fix for missing started/stopped playback events

### DIFF
--- a/src/FlakaPlayer.ts
+++ b/src/FlakaPlayer.ts
@@ -221,7 +221,7 @@ export class FlakaPlayer {
         time: stats.manifestTimeSeconds,
       });
 
-      if (this.options.reportManifestLoadedTime && stats.manifestTimeSeconds) {
+      if (this.options.reportManifestLoadedTime) {
         this.options.reportManifestLoadedTime(track, stats.manifestTimeSeconds);
       }
       if (/Safari/.test(navigator.userAgent) && /Apple Computer/.test(navigator.vendor)) {

--- a/src/FlakaPlayer.ts
+++ b/src/FlakaPlayer.ts
@@ -221,6 +221,8 @@ export class FlakaPlayer {
         time: stats.manifestTimeSeconds,
       });
 
+      // manifestTimeSeconds on safari is returning Nan atm, but we are not using this data in web player,
+      // so removed it from condition
       if (this.options.reportManifestLoadedTime) {
         this.options.reportManifestLoadedTime(track, stats.manifestTimeSeconds);
       }


### PR DESCRIPTION
On Safari manifestLoadTime is NaN for some reason, as we are not using this info ATM in web just forward it.